### PR TITLE
Auto farm update - lowest resource town first + storage %

### DIFF
--- a/src/autoFarm.js
+++ b/src/autoFarm.js
@@ -172,7 +172,7 @@ class AutoFarm extends ModernUtil {
             town.avgResource = avgResource;
 
             // If any resource above storage setting -> do not farm
-            if((wood / storage) > this.percent || (wood / storage) > this.percent || (wood / storage) > this.percent){
+            if((wood / storage) > this.percent && (wood / storage) > this.percent && (wood / storage) > this.percent){
                 continue;
             }
 

--- a/src/autoFarm.js
+++ b/src/autoFarm.js
@@ -168,11 +168,14 @@ class AutoFarm extends ModernUtil {
             if (on_small_island) continue;
 
             const { wood, stone, iron, storage } = uw.ITowns.getTown(id).resources();
-            let avgResource = (wood + stone + iron) / storage;
+            let avgResource = (wood + stone + iron) / (storage * 3);
             town.avgResource = avgResource;
 
             // If any resource above storage setting -> do not farm
-            if((wood / storage) > this.percent && (wood / storage) > this.percent && (wood / storage) > this.percent){
+            // if((wood / storage) > this.percent && (wood / storage) > this.percent && (wood / storage) > this.percent){
+
+            // If avg resource above storage setting -> do not farm
+            if(avgResource > this.percent){
                 continue;
             }
 

--- a/src/autoFarm.js
+++ b/src/autoFarm.js
@@ -290,6 +290,7 @@ class AutoFarm extends ModernUtil {
                     if (farm_town.attributes.id != relation.attributes.farm_town_id) continue;
                     if (relation.attributes.relation_status !== 1) continue;
                     if (relation.attributes.lootable_at !== null && now < relation.attributes.lootable_at) continue;
+                    if (relation.attributes.loot !== null && (4000 + relation.attributes.expansion_stage * 1000) - relation.attributes.loot < 115) continue;
 
                     this.claimSingle(town_id, relation.attributes.farm_town_id, relation.id, Math.ceil(this.timing / 600_000));
                     await this.sleep(Math.random() * 1000 + 500);


### PR DESCRIPTION
Hello there, I used the bot but noticed two "issues" after a night's use. 
* Only a single city had collected the farming villages for any given island.
* It went overboard on the storage and didn't consider the storage % chosen.

So, I decided to change the code and ended up adding a few features:
* added 2 extra storage % buttons (60%, 70%);
* fixed storage % setting not being considered (since this isn't my code, I tried my best to see if the variable "this.percent" was being used in the AutoFarm class, but didn't detect it anywhere); 
* changed the AutoFarm.generateList to include the lowest resource town per island;
* Increased the number of farms that can be farmed per instance.
* Changed the delay between farms to be a random number from .5s-1.5s;

ETA:
* Check if there's enough resources left in the farming village before trying to claim 